### PR TITLE
Method for killing child processes for Windows was corrected

### DIFF
--- a/src/core/lib/testHelpers.js
+++ b/src/core/lib/testHelpers.js
@@ -108,14 +108,22 @@ export default class {
         const cmd = commandArr.shift();
         const execObj = spawn(cmd, commandArr, {
             cwd: path.resolve(__dirname, "../../.."),
-            detached: true,
+            // detached: true,
         });
         return execObj;
     }
 
     /* istanbul ignore file */
-    killProcess(pid) {
-        process.kill(-pid);
+    killProcess(childProcess, pid) {
+        if (childProcess) {
+            childProcess.stdout.destroy();
+            childProcess.stderr.destroy();
+            childProcess.kill();
+            // process.kill(-(childProcess.pid));
+        }
+        if (pid) {
+            process.kill(-pid);
+        }
     }
 
     /* istanbul ignore file */

--- a/src/core/tests/20-server.test.js
+++ b/src/core/tests/20-server.test.js
@@ -40,7 +40,7 @@ test("Server availability (200)", async () => {
     } catch {
         // Ignore
     }
-    helpers.killProcess(childProcess.pid);
+    helpers.killProcess(childProcess);
     expect(response ? response.status : 0).toBe(200);
     serverPid = serverPid.filter(i => i !== childProcess.pid);
 });
@@ -64,7 +64,7 @@ test("Server availability (404)", async () => {
     } catch (e) {
         expect(e && e.response ? e.response.status : 0).toBe(404);
     }
-    helpers.killProcess(childProcess.pid);
+    helpers.killProcess(childProcess);
     serverPid = serverPid.filter(i => i !== childProcess.pid);
 });
 
@@ -88,14 +88,14 @@ test("Test Page", async () => {
         expect(response.data).toMatch(`site-description-${language}`);
         expect(response.data).toMatch(`site-content-${language}`);
     }
-    helpers.killProcess(childProcess.pid);
+    helpers.killProcess(childProcess);
     serverPid = serverPid.filter(i => i !== childProcess.pid);
 });
 
 afterAll(async () => {
     for (const pid of serverPid) {
         try {
-            helpers.killProcess(pid);
+            helpers.killProcess(null, pid);
         } catch {
             // Ignore
         }

--- a/src/core/tests/30-login.test.js
+++ b/src/core/tests/30-login.test.js
@@ -72,14 +72,14 @@ test("Login", async () => {
         visible: true,
         timeout: 15000
     });
-    helpers.killProcess(childProcess.pid);
+    helpers.killProcess(childProcess);
     serverPid = serverPid.filter(i => i !== childProcess.pid);
 });
 
 afterAll(async () => {
     for (const pid of serverPid) {
         try {
-            helpers.killProcess(pid);
+            helpers.killProcess(null, pid);
         } catch {
             // Ignore
         }


### PR DESCRIPTION
Destroy methods were added for output and error of childProcesses to TestHelpers, detached option was commented in execObj in TestHelpers; According to this changes were corrected tests in 30-login.test and 20-server.test